### PR TITLE
Improve A-AddRental and Transaction_ID generation

### DIFF
--- a/src/main/java/transaction/Transaction.java
+++ b/src/main/java/transaction/Transaction.java
@@ -7,7 +7,7 @@ import static parser.TransactionParser.dateTimeFormatter;
 public class Transaction {
     public static final int NUMBER_OF_PARAMETERS = 5;
     private static int transactionCounter = 1;
-    private final String transactionId;
+    private String transactionId;
     private final String carLicensePlate;
     private final String customer;
     private final int duration;
@@ -17,7 +17,6 @@ public class Transaction {
 
     public Transaction(String carLicensePlate, String customer, int duration,
                        LocalDate startDate) {
-        this.transactionId = "TX" + transactionCounter++;
         this.carLicensePlate = carLicensePlate;
         this.customer = customer;
         this.duration = duration;
@@ -28,13 +27,19 @@ public class Transaction {
 
     public Transaction(String carLicensePlate, String customer, int duration, LocalDate startDate
             , boolean isCompleted) {
-        this.transactionId = "TX" + transactionCounter++;
         this.carLicensePlate = carLicensePlate;
         this.customer = customer;
         this.duration = duration;
         this.startDate = startDate;
         this.endDate = startDate.plusDays(duration);
         this.isCompleted = isCompleted;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+    public static String generateTransactionId() {
+        return "TX" + transactionCounter++;
     }
 
     public int getDuration() {
@@ -52,6 +57,7 @@ public class Transaction {
     public String getTransactionId() {
         return transactionId;
     }
+
 
     private String durationtoString(){
         if(duration == 1) {

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -1,13 +1,12 @@
 package transaction;
 
 import car.CarList;
-import transaction.Transaction;
+
 import exceptions.CarException;
 import parser.CarParser;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.UUID;
+
 
 public class TransactionList {
 

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -68,6 +68,7 @@ public class TransactionList {
         // Assert that the transaction is not null
         assert transaction != null : "Transaction to add should not be null.";
 
+        transaction.setTransactionId(Transaction.generateTransactionId());
         transactionList.add(transaction);
 
         // Assert that the transaction was added successfully
@@ -191,6 +192,8 @@ public class TransactionList {
     }
 
     public static void markCompletedByTxId(String txId) {
+        // Assert that txId is not null
+        assert txId != null : "Transaction ID to mark as completed should not be null.";
 
         for (Transaction transaction : transactionList) {
             // Assert that each transaction is not null

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -1,20 +1,24 @@
 package transaction;
 
 import car.CarList;
+import transaction.Transaction;
 import exceptions.CarException;
 import parser.CarParser;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.UUID;
 
 public class TransactionList {
 
     // Ensure the transaction list is initialized properly
     private static final ArrayList<Transaction> transactionList = new ArrayList<>();
-
     public static void addTx(Transaction transaction) {
         // Assert that the transaction is not null
         assert transaction != null : "Transaction to add should not be null.";
 
         String licensePlateNumber = transaction.getCarLicensePlate();
+        String customerName = transaction.getCustomer();
 
         // Assert that the license plate number is not null
         assert licensePlateNumber != null : "License plate number should not be null.";
@@ -27,11 +31,30 @@ public class TransactionList {
             throw CarException.licensePlateNumberNotFound();
         }
 
+        for (Transaction tx : transactionList) {
+            if (tx.getCarLicensePlate().equals(licensePlateNumber) &&
+                    datesOverlap(tx.getStartDate(), tx.getEndDate(),
+                            transaction.getStartDate(), transaction.getEndDate())) {
+                System.out.println("Car " + licensePlateNumber +
+                        " is already rented during this period. Transaction not added.");
+                return;
+            }
+
+            if (tx.getCustomer().equalsIgnoreCase(customerName) &&
+                    datesOverlap(tx.getStartDate(), tx.getEndDate(),
+                            transaction.getStartDate(), transaction.getEndDate())) {
+                System.out.println("Customer " + customerName +
+                        " already has a rental during this period. Transaction not added.");
+                return;
+            }
+        }
+
         // Assert that the license plate number is valid and exists before adding
         assert CarParser.isValidLicensePlateNumber(licensePlateNumber)
                 && CarList.isExistingLicensePlateNumber(licensePlateNumber)
                 : "License plate number must be valid and exist in CarList.";
 
+        transaction.setTransactionId(Transaction.generateTransactionId());
         transactionList.add(transaction);
 
         // Assert that the transaction was added successfully
@@ -222,6 +245,12 @@ public class TransactionList {
 
     public static ArrayList<Transaction> getTransactionList(){
         return transactionList;
+    }
+
+    private static boolean datesOverlap(LocalDate start1, LocalDate end1,
+                                        LocalDate start2, LocalDate end2) {
+        return (start1.isBefore(end2) && end1.isAfter(start2)) || start1.equals(start2)
+                || end1.equals(end2);
     }
 
 }

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 
 
 public class TransactionList {
-
     // Ensure the transaction list is initialized properly
     private static final ArrayList<Transaction> transactionList = new ArrayList<>();
     public static void addTx(Transaction transaction) {
@@ -31,17 +30,18 @@ public class TransactionList {
         }
 
         for (Transaction tx : transactionList) {
-            if (tx.getCarLicensePlate().equals(licensePlateNumber) &&
-                    datesOverlap(tx.getStartDate(), tx.getEndDate(),
-                            transaction.getStartDate(), transaction.getEndDate())) {
+            boolean isCarInTxList = tx.getCarLicensePlate().equals(licensePlateNumber);
+            boolean isCustomerInTxList = tx.getCustomer().equalsIgnoreCase(customerName);
+            boolean doDatesOverlap =  datesOverlap(tx.getStartDate(), tx.getEndDate(),
+                    transaction.getStartDate(), transaction.getEndDate());
+
+            if (isCarInTxList && doDatesOverlap) {
                 System.out.println("Car " + licensePlateNumber +
                         " is already rented during this period. Transaction not added.");
                 return;
             }
 
-            if (tx.getCustomer().equalsIgnoreCase(customerName) &&
-                    datesOverlap(tx.getStartDate(), tx.getEndDate(),
-                            transaction.getStartDate(), transaction.getEndDate())) {
+            if (isCustomerInTxList && doDatesOverlap) {
                 System.out.println("Customer " + customerName +
                         " already has a rental during this period. Transaction not added.");
                 return;

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -191,8 +191,6 @@ public class TransactionList {
     }
 
     public static void markCompletedByTxId(String txId) {
-        // Assert that txId is not null
-        assert txId != null : "Transaction ID to mark as completed should not be null.";
 
         for (Transaction transaction : transactionList) {
             // Assert that each transaction is not null

--- a/src/test/java/transaction/TransactionTest.java
+++ b/src/test/java/transaction/TransactionTest.java
@@ -20,7 +20,9 @@ class TransactionTest {
         LocalDate startDate1 = LocalDate.parse("01-10-2024", dateTimeFormatter);
         LocalDate startDate2 = LocalDate.parse("02-10-2024", dateTimeFormatter);
         transaction1 = new Transaction("ABC-123", "John Doe", 5, startDate1);
+        transaction1.setTransactionId(Transaction.generateTransactionId());
         transaction2 = new Transaction("XYZ-789", "Jane Smith", 3, startDate2);
+        transaction2.setTransactionId(Transaction.generateTransactionId());
     }
 
     @Test
@@ -95,7 +97,9 @@ class TransactionTest {
         LocalDate startDate3 = LocalDate.parse("03-10-2024", dateTimeFormatter);
         LocalDate startDate4 = LocalDate.parse("04-10-2024", dateTimeFormatter);
         Transaction transaction3 = new Transaction("LMN-456", "Alice Johnson", 2, startDate3);
+        transaction3.setTransactionId(Transaction.generateTransactionId());
         Transaction transaction4 = new Transaction("DEF-321", "Bob Brown", 4, startDate4);
+        transaction4.setTransactionId(Transaction.generateTransactionId());
 
         assertEquals("TX16", transaction3.getTransactionId(), "Third transaction ID should be TX3");
         assertEquals("TX17", transaction4.getTransactionId(), "Fourth transaction ID should be TX4");


### PR DESCRIPTION
Improve add-tx to fail for overlapping rental period for customer and car. Fixed transaction id generation bug where it will only be generated when add-tx is sucessfully