### PR TITLE
Fixed bug: find-tx-by-customer & duration not shown when add-tx with 1 day

### DIFF
--- a/src/main/java/parser/TransactionParser.java
+++ b/src/main/java/parser/TransactionParser.java
@@ -130,7 +130,7 @@ public class TransactionParser {
             System.out.println(FIND_TRANSACTION_BY_CUSTOMER_FORMAT);
             return;
         }
-        TransactionList.findTxsByCustomer(words[2].toLowerCase());
+        TransactionList.findTxsByCustomer(words[2]);
     }
 
     public static void parseRemoveTx(String userInput){

--- a/src/main/java/transaction/Transaction.java
+++ b/src/main/java/transaction/Transaction.java
@@ -58,7 +58,7 @@ public class Transaction {
 
     private String durationtoString(){
         if(duration == 1) {
-            return " day";
+            return "1 day";
         } else {
             return duration + " days";
         }

--- a/src/main/java/transaction/TransactionList.java
+++ b/src/main/java/transaction/TransactionList.java
@@ -215,13 +215,13 @@ public class TransactionList {
         for (Transaction transaction : transactionList) {
             // Assert that each transaction is not null
             assert transaction != null : "Transaction in the list should not be null.";
-            if (transaction.getCustomer().toLowerCase().contains(customer)) {
+            if (transaction.getCustomer().toLowerCase().contains(customer.toLowerCase())) {
                 found = true;
                 System.out.println(transaction);
             }
         }
         if (!found) {
-            System.out.println("none");
+            System.out.println("None");
         }
     }
 

--- a/src/test/java/transaction/TransactionListTest.java
+++ b/src/test/java/transaction/TransactionListTest.java
@@ -368,7 +368,7 @@ class TransactionListTest {
         TransactionList.findTxsByCustomer("Alice Johnson");
 
         String expectedOutput = "Transaction(s) by Alice Johnson found:" + System.lineSeparator() +
-                "none" + System.lineSeparator();
+                "None" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString(), "Should indicate that no transactions was found");
     }
 


### PR DESCRIPTION
 to display exact input from customer and not lowercase input

when add-tx with 1 day duration, the display will show "1 day" now instead of "day"